### PR TITLE
:construction: Dockerize, fixes DP-417

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# copy and start customizing
+# cp .env.example .env
+JSON_LOCATION=./json
+REDIS_HOST=cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .idea/
+json/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ so this frontend will get the files it needs.
 If you are having trouble, make sure that json files are in `json/` and you can
 view the JSON files appropriately.
 
+#### Docker
+It is also possible to run the frontned as a Docker container.
+
+1. Run the [ethgasstation-backend](https://github.com/SettleFinance/ethgasstation-backend) with docker-compose
+2. Back to the frontend to copy/edit the environment variables: `cp .env.example .env`
+3. Run `docker-compose up`
+
 #### Using Redis with this legacy frontend
 
 It is possible to separate the backend and frontend, and not run all of the ETH

--- a/build/php/common.php
+++ b/build/php/common.php
@@ -10,7 +10,7 @@ define('DB_HOST', 'localhost');
 define('DB_USERNAME', 'ethgas');
 define('DB_PASSWORD', 'station');
 define('DB_NAME', 'tx');
-define('JSON_LOCATION', '/var/www/html/egs/ethgasstation-frontend/json');
+define('JSON_LOCATION', getenv('JSON_LOCATION') ?: '/var/www/html/egs/ethgasstation-frontend/json');
 
 // hostname to put in template links
 define('EGS_HOSTNAME', 'https://ethgasstation.info');

--- a/data_analysis/make_json.py
+++ b/data_analysis/make_json.py
@@ -30,7 +30,7 @@ import redis.exceptions
     poor access rules set, this file may leak these credentials.
 """
 REDIS_INFO = {
-    'host': 'localhost',
+    'host': (os.environ.get("REDIS_HOST") or "localhost"),
     'port': 6379,
     'auth': None
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3"
+services:
+  frontend:
+    image: php:7.4-cli
+    working_dir: /app
+    command: php -S 0.0.0.0:8000
+    environment:
+      - JSON_LOCATION
+    ports:
+      - "8000:8000"
+    networks:
+      # access to the backend database
+      - ethgasstation-backend_default
+    volumes:
+      - ./:/app
+  worker:
+    image: python:3.6-slim
+    working_dir: /app
+    command: |
+      bash -c "pip install redis && mkdir -p json && python /app/data_analysis/make_json.py $JSON_LOCATION"
+    environment:
+      - JSON_LOCATION
+      - REDIS_HOST
+    networks:
+      # access to the backend cache
+      - ethgasstation-backend_default
+    volumes:
+      - ./:/app
+# share the same network as the backend so its database and cache can be used
+networks:
+  ethgasstation-backend_default:
+    external: true


### PR DESCRIPTION
Dockerize the project via `docker-compose.yml`.
The compose file consists in two containers:
- frontend: serves the pages with PHP and consumes JSON files
- worker: pulls backend data from Redis and write to JSON files

Both containers need to be in the same network as the backend containers.
The frontend to use the shared MariaDB database and the worker to use
the shared Redis cache.

Also make it possible to dynamically change `JSON_LOCATION` and `REDIS_HOST`
via environment variables so manually editing is no longer needed.