### PR TITLE
:sparkles: Fetch EIP-1559 data from the new backend, fixes DP-403

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .env
+venv
 .idea/
 json/
+*.pyc
+__pycache__

--- a/build/php/data_py.php
+++ b/build/php/data_py.php
@@ -29,6 +29,9 @@ $gpRecs2 = json_decode($gpRecsString2, true);
 $predictString = get_json_file("predictTable.json");
 $predictTable = json_decode($predictString, true);
 
+$gpTipString = get_json_file("max-priority-fee-per-gas-estimate.json");
+$gpTip = json_decode($gpTipString, true);
+
 $rowString = get_json_file("txDataLast10k.json");
 $row = json_decode($rowString, true);
 // Get values for Misc transactions table

--- a/data_analysis/fetch_eip1559_data.py
+++ b/data_analysis/fetch_eip1559_data.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Fetches EIP-1559 data from the new backend and dump to JSON.
+Using the same approach of the existing ones of dumping backend data to JSON files.
+However this data is fetched directly from the new backend rather than from Redis.
+There're two advantages of re-using this design for displaying EIP-1559 data:
+    1) Easier to fit to the existing design
+    2) Make the process more async and non-blocking for the frontend
+"""
+import os
+import logging
+import argparse
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+NETWORK = "mainnet"
+BASE_URL = "https://egs-backend-v2-staging.defipulse.com"
+ENDPOINT = f"/api/max-priority-fee-per-gas-estimate?network={NETWORK}"
+
+
+def url2filename(url: str):
+    """
+    Given an URL, returns a local (JSON) filename it corresponds to.
+    >>> url = "https://egs-backend-v2.defipulse.com/api/base-fee-per-gas?network=mainnet"
+    >>> url2filename(url)
+    'base-fee-per-gas.json'
+    """
+    path = urlparse(url).path
+    basename = os.path.basename(path)
+    return f"{basename}.json"
+
+
+def fetch_data(destination: str):
+    url = f"{BASE_URL}{ENDPOINT}"
+    filename = url2filename(url)
+    destination = Path(destination) / filename
+    try:
+        response = urllib.request.urlopen(url)
+        content = response.read()
+    except urllib.error.HTTPError as e:
+        extra = {"url": url}
+        logger.error("Error fetching from backend", exc_info=True, extra=extra)
+        # hacky gracefully fail (most-likely pre-london)
+        # we want to still display data
+        # ideally some of this should also be handled frontend side
+        # but we prefer not to touch the legacy (PHP) frontend too much
+        content = b'{"instant":2,"fast":1,"standard":1}'
+    with open(destination, "w") as f:
+        f.write(content.decode())
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch EIP-1559 estimations and dump to JSON"
+    )
+    parser.add_argument(
+        "destination",
+        help="Destination directory for dumping the JSON files",
+    )
+    args = parser.parse_args()
+    fetch_data(args.destination)
+
+
+if __name__ == "__main__":
+    main()

--- a/data_analysis/make_json.py
+++ b/data_analysis/make_json.py
@@ -21,6 +21,7 @@ import time
 
 from redis import StrictRedis
 import redis.exceptions
+from fetch_eip1559_data import fetch_data
 
 
 """
@@ -79,6 +80,7 @@ def main():
                     print("Output directory invalid.", file=sys.stderr)
                     sys.exit(1)
 
+                fetch_data(output_dir)
                 for redis_key in REDIS_JSON_DATA_FILES:
                     filename = redis_key[1:] + '.json'
                     output_filepath = os.path.join(output_dir, filename)

--- a/index.php
+++ b/index.php
@@ -150,6 +150,49 @@
                     </div>
                   </div>
                 </div>
+
+                <div class="<?php echo (isset($_GET['eip1559']) ? "show" : "hidden") ?>">
+                  <div class="top_tiles_title">
+                    Recommended (<a href="https://ethgasstation.info/blog/eip-1559/">EIP-1559</a>) tipping
+                  </div>
+
+                  <div class="col-md-4 col-sm-4 col-xs-6 tile_stats_count">
+                    <div>
+                      <div class="count fast">
+                        <?php echo ($gpTip['instant']) ?>
+                      </div>
+                      <div class="divider"></div>
+                      <div class="text-container">
+                        <div class="count_top"><span>trader</span><span>< ASAP</span></div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="col-md-4 col-sm-4 col-xs-6 tile_stats_count">
+                    <div>
+                      <div class="count standard">
+                        <?php echo ($gpTip['fast']) ?>
+                      </div>
+                      <div class="divider"></div>
+                      <div class="text-container">
+                        <div class="count_top"><span>fast</span><span>< 2m</span></div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="col-md-4 col-sm-4 col-xs-6 tile_stats_count">
+                    <div>
+                      <div class="count safe_low" id="medTxTip">
+                        <?php echo ($gpTip['standard']) ?>
+                      </div>
+                      <div class="divider"></div>
+                      <div class="text-container">
+                        <div class="count_top"><span>standard</span><span>< 5m</span></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
               </div>
             </div>
           <!-- /top tiles end -->


### PR DESCRIPTION
Fetch the tipping data from the new (staging) backend.
Display the recommended tipping on the front page below the recommended
gas price widget.
The widget is hidden (CSS) pre-london fork and should automatically show
at block number 12965000.
Also updates the `.gitignore` with Python files patterns.