### PR TITLE
Base fee API has changed (fields names and unit)

### DIFF
--- a/feedback.html
+++ b/feedback.html
@@ -42,7 +42,7 @@
         <div class="feedback_back">Back to ETH Gas Station
         </div>
       </a>
-      <iframe id="typeform-full" width="100%" height="100%" frameborder="0" src="https://settlefinance.typeform.com/to/gVjNGO">
+      <iframe id="typeform-full" width="100%" height="100%" frameborder="0" src="https://concourseopen.typeform.com/to/gVjNGO">
       </iframe>
     </div>
   </div>

--- a/index.php
+++ b/index.php
@@ -197,8 +197,8 @@
                     </div>
 
                     <!-- Divide by 1000000000 to represent in Gwei -->
-                    <p class="base-fee">Next block base fee: <?php echo ($baseFee['baseFeePerGas']/1000000000) ?></p>
-                    <p class="base-fee">Previous block base fee: <?php echo ($baseFee['nextBaseFeePerGas']/1000000000) ?></p>
+                    <p class="base-fee">Next block base fee: <?php echo ($baseFee['baseFee']) ?></p>
+                    <p class="base-fee">Previous block base fee: <?php echo ($baseFee['nextBaseFee']) ?></p>
 
                   </div>
                 </div>


### PR DESCRIPTION
`baseFeePerGas` field is now using the short alias `baseFee` and returns gwei value.